### PR TITLE
9-jupyter-lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Balena.io will build and deploy the containers to your target.
 
 It's that easy!
 
+## Configure via [environment variables](https://docs.resin.io/management/env-vars/)
+Variable Name | Value | Description | Default
+------------ | ------------- | ------------- | -------------
+**`JUPYTER_MING_PASS`** | `STRING` | the password Jupyter Labs will start up with | mingstack
+
 # More detail
 
 Here's an example of what you will see on the Balena dashboard.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ volumes:
     influxdb-data:
     nodered-data:
     grafana-data:
+    jupyterlab-data:
 services:
   nodered:
     restart: always
@@ -37,6 +38,14 @@ services:
     build: ./mosquitto
     ports:
       - "1883:1883"
+  jupyterlab:
+    restart: always
+    build: ./jupyterlab
+    ports:
+      - "8888:8888"
+    volumes:
+      - 'jupyterlab-data:/data'
+
 #  bridge:
 #    restart: always
 #    build: ./bridge

--- a/jupyterlab/Dockerfile.template
+++ b/jupyterlab/Dockerfile.template
@@ -1,0 +1,25 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
+
+RUN install_packages nodejs npm
+RUN install_packages python3 python3-pip python3-dev python3-zmq python3-pandas python3-setuptools python3-markupsafe python3-prometheus-client python3-tornado python3-wheel build-essential
+RUN install_packages tini
+COPY start.sh /usr/src/app/jupyter/start.sh
+
+COPY requirements.txt /root/
+RUN pip3 install -r /root/requirements.txt && \
+    jupyter lab --generate-config
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+RUN mkdir /data
+
+RUN useradd -Ms /bin/bash -d /usr/src/app/jupyter jupyter \
+    && chown -R jupyter:jupyter /data \
+    && chown -R jupyter:jupyter /usr/src/app/jupyter
+
+USER jupyter
+
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 8888
+
+CMD ["/bin/bash", "/usr/src/app/jupyter/start.sh"]

--- a/jupyterlab/Dockerfile.template
+++ b/jupyterlab/Dockerfile.template
@@ -1,14 +1,15 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
 
-RUN install_packages nodejs npm
-RUN install_packages python3 python3-pip python3-dev python3-zmq python3-pandas python3-setuptools python3-markupsafe python3-prometheus-client python3-tornado python3-wheel build-essential
-RUN install_packages tini
+RUN install_packages nodejs npm python3 python3-pip python3-dev python3-zmq python3-pandas python3-setuptools python3-markupsafe python3-prometheus-client python3-tornado python3-wheel build-essential tini
 COPY start.sh /usr/src/app/jupyter/start.sh
 
 COPY requirements.txt /root/
 RUN pip3 install -r /root/requirements.txt && \
     jupyter lab --generate-config
 
+# This usage of Tini is in order to prevent potential issues with PID reaping as mentioned here:
+# https://jupyter-notebook.readthedocs.io/en/stable/public_server.html
+ 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 RUN mkdir /data
 

--- a/jupyterlab/requirements.txt
+++ b/jupyterlab/requirements.txt
@@ -1,0 +1,1 @@
+jupyterlab

--- a/jupyterlab/start.sh
+++ b/jupyterlab/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+MING_JUPYTER_DEFAULT_PASS=mingstack
+
+# If MING_JUPYTER_PASS is set then hash this password via Jupyter and store it in hashed_password
+# otherwise use MING_JUPYTER_DEFAULT_PASS as none has been set by the user
+
+if [[ -n "$MING_JUPYTER_PASS" ]]; then
+  hashed_password=$(python3 -c "from notebook.auth import passwd; print(passwd('$MING_JUPYTER_PASS'))")
+else
+  hashed_password=$(python3 -c "from notebook.auth import passwd; print(passwd('$MING_JUPYTER_DEFAULT_PASS'))")
+fi
+
+jupyter lab --ip=0.0.0.0 --NotebookApp.password="$hashed_password"
+


### PR DESCRIPTION
This PR adds support for [Jupyter Labs](https://github.com/jupyterlab/jupyterlab).

With it comes a new environment variable that will be used to change the password Jupyter starts with, since it requires usage of the terminal on the device otherwise, which is a bit messy. Since the security of this install isn't too much of a priority yet, this is fine for now.

I've added this table to the readme, we can add future variables and organize the user-facing configuration they offer using this format in the future.

---
## Configure via [environment variables](https://docs.resin.io/management/env-vars/)
Variable Name | Value | Description | Default
------------ | ------------- | ------------- | -------------
**`JUPYTER_MING_PASS`** | `STRING` | the password Jupyter Labs will start up with | mingstack
---

However, I do want to in the future figure this out such that we have a better way of handling this.

All notebooks are stored in `/data` which has its own persistent volume in docker-compose.yml.

This uses our own maintained dockerfile, since there is a lot of variability in the packaging for Jupyter and  its components. There's a bit of room for improvement in that we should move to Alpine once its `py3-component` packages are moved from edge@testing to the latest stable so we can save some space and build time.