### PR TITLE
rhasspy: Add rhasspy-server reference implementation, off by default 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
     grafana-data:
     jupyterlab-data:
     homeassistant-data:
+    rhasspy-data:
 services:
   nodered:
     restart: always
@@ -54,6 +55,16 @@ services:
 #      - "8123:8123" 
 #    volumes:
 #      - 'homeassistant-data:/config'
+#  rhasspy:
+#    restart: always
+#    build: ./rhasspy
+#    ports:
+#      - "12101:12101"
+#    volumes:
+#      - 'rhasspy-data:/profiles'
+#    devices:
+#      - "/dev/snd:/dev/snd"
+#    command: --user-profiles /profiles --profile en
 #  ap:
 #    build: ./ap
 #    restart: always

--- a/rhasspy/Dockerfile
+++ b/rhasspy/Dockerfile
@@ -1,0 +1,1 @@
+FROM synesthesiam/rhasspy-server:latest

--- a/rhasspy/Dockerfile.raspberrypi3
+++ b/rhasspy/Dockerfile.raspberrypi3
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm synesthesiam/rhasspy-server:latest

--- a/rhasspy/Dockerfile.template
+++ b/rhasspy/Dockerfile.template
@@ -1,0 +1,1 @@
+FROM --platform=linux/%%BALENA_ARCH%% synesthesiam/rhasspy-server:latest


### PR DESCRIPTION
I've had this running for a few days and haven't really noticed any issues, it's quite a complex project so it'll take some time to imagine ways to integrate it in a more minimal manner without a webserver. This provides the most wholesome way of getting started with and interacting with Rhasspy. 

The documentation I'm following regarding usage of Rhasspy and Docker:
https://rhasspy.readthedocs.io/en/latest/installation/#docker